### PR TITLE
Fixing bug where pending tweens were not cleared properly via `UBUITween::Clear` for non-additive instances

### DIFF
--- a/Source/BUITween/Private/BUITween.cpp
+++ b/Source/BUITween/Private/BUITween.cpp
@@ -22,7 +22,7 @@ void UBUITween::Shutdown()
 
 FBUITweenInstance& UBUITween::Create( UWidget* pInWidget, float InDuration, float InDelay, bool bIsAdditive )
 {
-	// By default let's kill any existing tweens 
+	// By default let's kill any existing tweens
 	if ( !bIsAdditive )
 	{
 		Clear( pInWidget );
@@ -39,14 +39,14 @@ FBUITweenInstance& UBUITween::Create( UWidget* pInWidget, float InDuration, floa
 int32 UBUITween::Clear( UWidget* pInWidget )
 {
 	int32 NumRemoved = 0;
-	for ( int32 i = ActiveInstances.Num() - 1; i >= 0; --i )
-	{
-		if ( ActiveInstances[ i ].GetWidget().IsValid() && ActiveInstances[ i ].GetWidget() == pInWidget )
-		{
-			ActiveInstances.RemoveAt( i );
-			NumRemoved++;
-		}
-	}
+
+	auto DoesTweenMatchWidgetFn = [pInWidget](const FBUITweenInstance& CurTweenInstance) -> bool {
+		return ( CurTweenInstance.GetWidget().IsValid() && CurTweenInstance.GetWidget() == pInWidget );
+	};
+
+	NumRemoved += ActiveInstances.RemoveAll(DoesTweenMatchWidgetFn);
+	NumRemoved += InstancesToAdd.RemoveAll(DoesTweenMatchWidgetFn);
+
 	return NumRemoved;
 }
 

--- a/Source/BUITween/Private/BUITweenInstance.cpp
+++ b/Source/BUITween/Private/BUITweenInstance.cpp
@@ -7,9 +7,10 @@
 #include "Components/OverlaySlot.h"
 #include "Components/VerticalBoxSlot.h"
 #include "Components/HorizontalBoxSlot.h"
-#include "Components/Sizebox.h"
+#include "Components/SizeBox.h"
 #include "Blueprint/UserWidget.h"
 
+DEFINE_LOG_CATEGORY(LogBUITween);
 
 void FBUITweenInstance::Begin()
 {
@@ -19,7 +20,7 @@ void FBUITweenInstance::Begin()
 
 	if ( !pWidget.IsValid() )
 	{
-		UE_LOG( LogTemp, Warning, TEXT( "Trying to start invalid widget" ) );
+		UE_LOG( LogBUITween, Warning, TEXT( "Trying to start invalid widget" ) );
 		return;
 	}
 

--- a/Source/BUITween/Public/BUITweenInstance.h
+++ b/Source/BUITween/Public/BUITweenInstance.h
@@ -6,6 +6,8 @@
 
 DECLARE_DELEGATE_OneParam( FBUITweenSignature, UWidget* /*Owner*/ );
 
+BUITWEEN_API DECLARE_LOG_CATEGORY_EXTERN(LogBUITween, Log, All);
+
 template<typename T>
 class TBUITweenProp
 {


### PR DESCRIPTION
Additional cleanup:
- Fix clang compilation error due to improper casing of engine file `#include "Components/SizeBox.h"`
- Created specific logging category for UI tweening logs (instead of using `LogTemp` which is not intended for production)